### PR TITLE
Increase UPLOAD_APP_TIMEOUT default to 1 hour

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/Configuration.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/util/Configuration.java
@@ -129,7 +129,7 @@ public class Configuration {
      * @see org.activiti.engine.impl.persistence.entity.JobEntityManager#schedule()
      */
     public static final Integer DEFAULT_CONTROLLER_POLLING_INTERVAL = 6; // 6 second(s)
-    public static final Integer DEFAULT_UPLOAD_APP_TIMEOUT = 30 * 60; // 30 minute(s)
+    public static final Integer DEFAULT_UPLOAD_APP_TIMEOUT = 60 * 60; // 60 minute(s)
     public static final Boolean DEFAULT_SKIP_SSL_VALIDATION = false;
     public static final String DEFAULT_VERSION = "N/A";
     public static final Integer DEFAULT_CHANGE_LOG_LOCK_WAIT_TIME = 1; // 1 minute(s)


### PR DESCRIPTION
In non performent environments, the time it takes to analyze the application
files and upload them to the controller sometime takes more than half an hour.
Doubling the time-out to an hour, to improve resilience in such cases

Change-Id: I9121cbd8e4c29bca0bce36896fae929c2ba60896