### PR TITLE
Increase Activiti step timeout to 30 minutes

### DIFF
--- a/com.sap.cloud.lm.sl.cf.web/src/main/webapp/WEB-INF/activiti-context.xml
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/webapp/WEB-INF/activiti-context.xml
@@ -1,24 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns="http://www.springframework.org/schema/beans"
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/beans"
 
-	xsi:schemaLocation="
+    xsi:schemaLocation="
         http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans-4.2.xsd">
 
-	<bean id="processEngineConfiguration" class="org.activiti.spring.SpringProcessEngineConfiguration">
-		<property name="dataSource" ref="dataSource" />
-		<property name="transactionManager" ref="transactionManager" />
-		<property name="databaseSchemaUpdate" value="true" />
-		<property name="deploymentResources"
-			value="classpath*:/com/sap/cloud/lm/sl/cf/process/*.bpmn" />
-		<property name="failedJobCommandFactory">
-			<!-- By default Activiti will retry failed job. Disable this behavior. -->
-			<bean class="com.sap.cloud.lm.sl.cf.process.AbortFailedProcessCommandFactory" />
-		</property>
-	</bean>
+    <bean id="processEngineConfiguration" class="org.activiti.spring.SpringProcessEngineConfiguration">
+        <property name="dataSource" ref="dataSource" />
+        <property name="transactionManager" ref="transactionManager" />
+        <property name="databaseSchemaUpdate" value="true" />
+        <property name="deploymentResources" value="classpath*:/com/sap/cloud/lm/sl/cf/process/*.bpmn" />
+        <property name="failedJobCommandFactory">
+            <!-- By default Activiti will retry failed job. Disable this behavior. -->
+            <bean class="com.sap.cloud.lm.sl.cf.process.AbortFailedProcessCommandFactory" />
+        </property>
+        <property name="jobExecutor" ref="jobExecutor" />
+    </bean>
 
-	<bean id="processEngine" class="org.activiti.spring.ProcessEngineFactoryBean">
-		<property name="processEngineConfiguration" ref="processEngineConfiguration" />
-	</bean>
+    <bean id="jobExecutor" class="org.activiti.engine.impl.jobexecutor.DefaultJobExecutor">
+        <property name="lockTimeInMillis" value="1800000" /> <!-- 30 minute(s) -->
+    </bean>
+
+    <bean id="processEngine" class="org.activiti.spring.ProcessEngineFactoryBean">
+        <property name="processEngineConfiguration" ref="processEngineConfiguration" />
+    </bean>
 </beans>


### PR DESCRIPTION
There are some steps that might take longer than 5 minutes to finish (this is the default step timeout). For example, ValidateDeployParametersStep merges the chunks of an MTAR, so it may exceed that timeout for very large archives.

JIRA: LMCROSSITXSADEPLOY-700