### PR TITLE
Fix drop of unnamed unique constraint on HANA

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/liquibase/DropConfigurationRegistryUniqueConstraint.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/liquibase/DropConfigurationRegistryUniqueConstraint.java
@@ -17,7 +17,7 @@ import liquibase.exception.SetupException;
 
 public class DropConfigurationRegistryUniqueConstraint extends AbstractChange {
 
-    private static final String HANA_SEARCH_QUERY = "SELECT INDEX_NAME FROM INDEXES WHERE TABLE_NAME='CONFIGURATION_REGISTRY' AND INDEX_TYPE='CPBTREE UNIQUE'";
+    private static final String HANA_SEARCH_QUERY = "SELECT INDEX_NAME FROM INDEXES WHERE TABLE_NAME='CONFIGURATION_REGISTRY' AND CONSTRAINT LIKE '%UNIQUE%'";
     private static final String POSTGRESQL_SEARCH_QUERY = "SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME='configuration_registry' and CONSTRAINT_TYPE='UNIQUE'";
     private static final String DROP_QUERY = "ALTER TABLE configuration_registry DROP CONSTRAINT %s";
     private static final String HANA_CONSTRAINT_NAME_COLUMN = "INDEX_NAME";


### PR DESCRIPTION
Since version 2.50 of HANA, the index types for both our unique and
primary key constraints have changed from 'CPBTREE UNIQUE' to 'INVERTED
VALUE UNIQUE'. This means that we can no longer use the INDEX_TYPE
column to distinguish between the primary key and unique constraint for
our CONFIGURATION_REGISTRY table.