### PR TITLE
Fortify issues

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/activiti/ActivitiActionFactory.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/activiti/ActivitiActionFactory.java
@@ -1,5 +1,7 @@
 package com.sap.cloud.lm.sl.cf.core.activiti;
 
+import java.util.Locale;
+
 public class ActivitiActionFactory {
 
     public static final String ACTION_ID_RETRY = "retry";
@@ -7,7 +9,7 @@ public class ActivitiActionFactory {
     public static final String ACTION_ID_RESUME = "resume";
 
     public static ActivitiAction getAction(String actionId, ActivitiFacade activitiFacade, String userId) {
-        switch (actionId.toLowerCase()) {
+        switch (actionId.toLowerCase(Locale.ROOT)) {
             case ACTION_ID_ABORT:
                 return new AbortActivitiAction(activitiFacade, userId);
             case ACTION_ID_RETRY:

--- a/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/activiti/ActivitiActionFactoryTest.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/activiti/ActivitiActionFactoryTest.java
@@ -1,0 +1,38 @@
+package com.sap.cloud.lm.sl.cf.core.activiti;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class ActivitiActionFactoryTest {
+
+    private static final String RESUME_ACTION_ID = "resume";
+    private static final String RETRY_ACTION_ID = "retry";
+    private static final String USER_ID = "test-user";
+    private static final String ABORT_ACTION_ID = "abort";
+    @Mock
+    ActivitiFacade facade;
+
+    @Test
+    public void testAbortAction() {
+        testAction(ABORT_ACTION_ID, AbortActivitiAction.class);
+    }
+
+    @Test
+    public void testRetryAction() {
+        testAction(RETRY_ACTION_ID, RetryActivitiAction.class);
+    }
+
+    @Test
+    public void testResumeAction() {
+        testAction(RESUME_ACTION_ID, ResumeActivitiAction.class);
+    }
+
+    private void testAction(String actionId, Class<? extends ActivitiAction> actionClass) {
+        ActivitiAction action = ActivitiActionFactory.getAction(actionId, facade, USER_ID);
+        assertEquals(action.getClass(), actionClass);
+        action = ActivitiActionFactory.getAction(actionId.toUpperCase(), facade, USER_ID);
+        assertEquals(action.getClass(), actionClass);
+    }
+}


### PR DESCRIPTION
Pair<String, String> tokenKey changed to volatile because of broken idiom, described in:
http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html