### PR TITLE
Fix drop of unnamed unique constraint on all HANA versions

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/liquibase/DropConfigurationRegistryUniqueConstraint.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/liquibase/DropConfigurationRegistryUniqueConstraint.java
@@ -2,8 +2,12 @@ package com.sap.cloud.lm.sl.cf.core.liquibase;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.sap.cloud.lm.sl.cf.core.message.Messages;
 import com.sap.cloud.lm.sl.cf.core.util.Configuration;
@@ -17,32 +21,18 @@ import liquibase.exception.SetupException;
 
 public class DropConfigurationRegistryUniqueConstraint extends AbstractChange {
 
-    private static final String HANA_SEARCH_QUERY = "SELECT INDEX_NAME FROM INDEXES WHERE TABLE_NAME='CONFIGURATION_REGISTRY' AND CONSTRAINT LIKE '%UNIQUE%'";
+    private static final String HANA_SEARCH_QUERY = "SELECT DISTINCT CONSTRAINT_NAME FROM CONSTRAINTS WHERE SCHEMA_NAME='%s' AND TABLE_NAME='CONFIGURATION_REGISTRY' AND IS_UNIQUE_KEY='TRUE' AND IS_PRIMARY_KEY='FALSE'";
     private static final String POSTGRESQL_SEARCH_QUERY = "SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME='configuration_registry' and CONSTRAINT_TYPE='UNIQUE'";
     private static final String DROP_QUERY = "ALTER TABLE configuration_registry DROP CONSTRAINT %s";
-    private static final String HANA_CONSTRAINT_NAME_COLUMN = "INDEX_NAME";
-    private static final String POSTGRESQL_CONSTRAINT_NAME_COLUMN_NAME = "CONSTRAINT_NAME";
+    private static final String CONSTRAINT_NAME_COLUMN = "CONSTRAINT_NAME";
+    private static final Set<DatabaseType> SUPPORTED_DATABASE_TYPES = new HashSet<>(
+        Arrays.asList(DatabaseType.HANA, DatabaseType.POSTGRESQL));
 
-    private String searchQuery;
-    private String constraintNameColumn;
+    private DatabaseType databaseType;
 
     @Override
     public void setUp() throws SetupException {
-        DatabaseType databaseType = Configuration.getInstance().getDatabaseType();
-        switch (databaseType) {
-            case POSTGRESQL:
-                searchQuery = POSTGRESQL_SEARCH_QUERY;
-                constraintNameColumn = POSTGRESQL_CONSTRAINT_NAME_COLUMN_NAME;
-                break;
-            case HANA:
-                searchQuery = HANA_SEARCH_QUERY;
-                constraintNameColumn = HANA_CONSTRAINT_NAME_COLUMN;
-                break;
-            default:
-                // Normally, one would throw an exception here, but we can't do that because the AuditLogManagerTest will fail.
-                logger.warn(
-                    MessageFormat.format(Messages.UNKNOWN_DB_TYPE_WILL_NOT_DROP_CONFIGURATION_REGISTRY_UNIQUE_CONSTRAINT, databaseType));
-        }
+        this.databaseType = Configuration.getInstance().getDatabaseType();
     }
 
     @Override
@@ -52,7 +42,10 @@ public class DropConfigurationRegistryUniqueConstraint extends AbstractChange {
 
     @Override
     public void execute(Database database) throws CustomChangeException {
-        if (searchQuery == null || constraintNameColumn == null) {
+        if (!SUPPORTED_DATABASE_TYPES.contains(databaseType)) {
+            // Normally, one would throw an exception here, but we can't do that because the AuditLogManagerTest will fail.
+            logger
+                .warn(MessageFormat.format(Messages.UNKNOWN_DB_TYPE_WILL_NOT_DROP_CONFIGURATION_REGISTRY_UNIQUE_CONSTRAINT, databaseType));
             return;
         }
         super.execute(database);
@@ -68,14 +61,27 @@ public class DropConfigurationRegistryUniqueConstraint extends AbstractChange {
         PreparedStatement preparedStatement = null;
 
         try {
+            String searchQuery = getSearchQuery(jdbcConnection);
             preparedStatement = jdbcConnection.prepareStatement(searchQuery);
             ResultSet result = preparedStatement.executeQuery();
             result.next();
-            String constraintName = result.getString(constraintNameColumn);
+            String constraintName = result.getString(CONSTRAINT_NAME_COLUMN);
             logger.info(String.format("Executed statement '%s' returned constraint name: %s", searchQuery, constraintName));
             return constraintName;
         } finally {
             JdbcUtil.closeQuietly(preparedStatement);
+        }
+    }
+
+    private String getSearchQuery(JdbcConnection jdbcConnection) throws SQLException {
+        switch (databaseType) {
+            case POSTGRESQL:
+                return POSTGRESQL_SEARCH_QUERY;
+            case HANA:
+                String schemaName = jdbcConnection.getUnderlyingConnection().getSchema();
+                return String.format(HANA_SEARCH_QUERY, schemaName);
+            default:
+                throw new IllegalStateException();
         }
     }
 


### PR DESCRIPTION
The SELECT query, which we used to find the unnamed configuration
registry unique constraint, only worked on some HANA versions. The new
one is supposed to be version independent.

BUG: XSBUG-2551