### PR TITLE
Fix issues in FilesApi

### DIFF
--- a/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/model/FileMetadata.java
+++ b/com.sap.cloud.lm.sl.cf.api/src/main/java/com/sap/cloud/lm/sl/cf/web/api/model/FileMetadata.java
@@ -1,13 +1,17 @@
 package com.sap.cloud.lm.sl.cf.web.api.model;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sap.cloud.lm.sl.mta.model.AuditableConfiguration;
+import com.sap.cloud.lm.sl.mta.model.ConfigurationIdentifier;
 
 import io.swagger.annotations.ApiModelProperty;
 
-public class FileMetadata {
+public class FileMetadata implements AuditableConfiguration {
 
     private String id = null;
     private String name = null;
@@ -160,5 +164,26 @@ public class FileMetadata {
             return "null";
         }
         return o.toString().replace("\n", "\n    ");
+    }
+
+    @Override
+    public String getConfigurationType() {
+        return "file metadata";
+    }
+
+    @Override
+    public String getConfiguratioName() {
+        return name;
+    }
+
+    @Override
+    public List<ConfigurationIdentifier> getConfigurationIdentifiers() {
+        List<ConfigurationIdentifier> configurationIdentifiers = new ArrayList<>();
+        configurationIdentifiers.add(new ConfigurationIdentifier("id", id));
+        configurationIdentifiers.add(new ConfigurationIdentifier("digest", digest));
+        configurationIdentifiers.add(new ConfigurationIdentifier("digestAlgorithm", digestAlgorithm));
+        configurationIdentifiers.add(new ConfigurationIdentifier("space", space));
+        configurationIdentifiers.add(new ConfigurationIdentifier("size", size.toString()));
+        return configurationIdentifiers;
     }
 }

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/message/Messages.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/message/Messages.java
@@ -41,6 +41,8 @@ public final class Messages {
     public static final String ORG_AND_SPACE_MUST_BE_SPECIFIED = "Org and space must be specified!";
     public static final String RETRIEVE_CONFIGURATION_SUBSCRIPTIONS_IN_ORG_AND_SPACE = "Retrieve configuration subscriptions in org {0} and space {1}";
     public static final String NOT_AUTHORIZED_TO_PERFORM_OPERATIONS_IN_SPACE = "You are not authorized to perform operations in the space with id {0}. You need a SpaceDeveloper role to operate in the space";
+    public static final String COULD_NOT_GET_FILES = "Could not get MTA files";
+    public static final String COULD_NOT_UPLOAD_FILE = "Could not upload MTA file";
 
     // WARN log messages
 


### PR DESCRIPTION
The WebApplicationException does not take in consideration the cause in the constructor. This makes the message of the exception disappear from the response.