### PR TITLE
Tag controller rest calls with request header

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/CloudFoundryClientFactory.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/CloudFoundryClientFactory.java
@@ -1,5 +1,7 @@
 package com.sap.cloud.lm.sl.cf.core.cf;
 
+import java.util.ArrayList;
+
 import javax.inject.Inject;
 
 import org.cloudfoundry.client.lib.CloudCredentials;
@@ -8,7 +10,9 @@ import org.cloudfoundry.client.lib.domain.CloudSpace;
 import org.cloudfoundry.client.lib.oauth2.OauthClient;
 import org.cloudfoundry.client.lib.rest.CloudControllerClient;
 import org.cloudfoundry.client.lib.rest.CloudControllerClientFactory;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.util.Assert;
+import org.springframework.web.client.RestTemplate;
 
 import com.sap.cloud.lm.sl.cf.client.CloudFoundryClientExtended;
 import com.sap.cloud.lm.sl.cf.client.CloudFoundryTokenProvider;
@@ -25,6 +29,7 @@ public class CloudFoundryClientFactory extends ClientFactory {
     @Override
     protected Pair<CloudFoundryOperations, TokenProvider> createClient(CloudCredentials credentials) {
         CloudControllerClientFactory factory = new CloudControllerClientFactory(null, configuration.shouldSkipSslValidation());
+        addTaggingInterceptor(factory.getRestTemplate());
         OauthClient oauthClient = createOauthClient();
         CloudControllerClient controllerClient = factory.newCloudController(configuration.getTargetURL(), credentials, null, oauthClient);
         return new Pair<CloudFoundryOperations, TokenProvider>(new CloudFoundryClientExtended(controllerClient),
@@ -35,6 +40,7 @@ public class CloudFoundryClientFactory extends ClientFactory {
     protected Pair<CloudFoundryOperations, TokenProvider> createClient(CloudCredentials credentials, String org, String space) {
         CloudControllerClientFactory factory = new CloudControllerClientFactory(null, configuration.shouldSkipSslValidation());
         CloudSpace sessionSpace = getSessionSpace(credentials, org, space);
+        addTaggingInterceptor(factory.getRestTemplate(), org, space);
         OauthClient oauthClient = createOauthClient();
         CloudControllerClient controllerClient = factory.newCloudController(configuration.getTargetURL(), credentials, sessionSpace,
             oauthClient);
@@ -45,11 +51,26 @@ public class CloudFoundryClientFactory extends ClientFactory {
     protected Pair<CloudFoundryOperations, TokenProvider> createClient(CloudCredentials credentials, String spaceId) {
         CloudControllerClientFactory factory = new CloudControllerClientFactory(null, configuration.shouldSkipSslValidation());
         CloudSpace sessionSpace = getSessionSpace(credentials, spaceId);
+        addTaggingInterceptor(factory.getRestTemplate(), sessionSpace.getOrganization()
+            .getName(), sessionSpace.getName());
         OauthClient oauthClient = createOauthClient();
         CloudControllerClient controllerClient = factory.newCloudController(configuration.getTargetURL(), credentials, sessionSpace,
             oauthClient);
         return new Pair<CloudFoundryOperations, TokenProvider>(new CloudFoundryClientExtended(controllerClient),
             new CloudFoundryTokenProvider(oauthClient));
+    }
+
+    private void addTaggingInterceptor(RestTemplate template) {
+        addTaggingInterceptor(template, null, null);
+    }
+
+    private void addTaggingInterceptor(RestTemplate template, String org, String space) {
+        if (template.getInterceptors() == null) {
+            template.setInterceptors(new ArrayList<>());
+        }
+        ClientHttpRequestInterceptor requestInterceptor = new TaggingRequestInterceptor(org, space);
+        template.getInterceptors()
+            .add(requestInterceptor);
     }
 
     protected CloudSpace getSessionSpace(CloudCredentials credentials, String orgName, String spaceName) {

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/TaggingRequestInterceptor.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/cf/TaggingRequestInterceptor.java
@@ -1,0 +1,58 @@
+package com.sap.cloud.lm.sl.cf.core.cf;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import com.sap.cloud.lm.sl.cf.core.util.Configuration;
+
+class TaggingRequestInterceptor implements ClientHttpRequestInterceptor {
+    public static final String TAG_HEADER_SPACE_NAME = "source-space";
+    public static final String TAG_HEADER_ORG_NAME = "source-org";
+    public static final String TAG_HEADER_NAME = "source";
+    private final String headerValue;
+    private String orgHeaderValue;
+    private String spaceHeaderValue;
+
+    TaggingRequestInterceptor(String org, String space) {
+        this();
+        this.orgHeaderValue = org;
+        this.spaceHeaderValue = space;
+    }
+
+    TaggingRequestInterceptor() {
+        this.headerValue = getHeaderValue();
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        HttpHeaders headers = request.getHeaders();
+        setHeader(headers, TAG_HEADER_NAME, headerValue);
+        if (orgHeaderValue != null && spaceHeaderValue != null) {
+            setHeader(headers, TAG_HEADER_ORG_NAME, orgHeaderValue);
+            setHeader(headers, TAG_HEADER_SPACE_NAME, spaceHeaderValue);
+        }
+        return execution.execute(request, body);
+    }
+
+    private void setHeader(HttpHeaders headers, String tagHeaderName, String headerValue) {
+        if (headers.containsKey(tagHeaderName)) {
+            return;
+        }
+        headers.add(tagHeaderName, headerValue);
+    }
+
+    String getHeaderValue() {
+        StringBuilder headerValueBuilder = new StringBuilder("MTA deploy-service v.");
+        headerValueBuilder.append(getConfiguration().getVersion());
+        return headerValueBuilder.toString();
+    }
+
+    protected Configuration getConfiguration() {
+        return Configuration.getInstance();
+    }
+}

--- a/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/helpers/MtaDescriptorPropertiesResolver.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/java/com/sap/cloud/lm/sl/cf/core/helpers/MtaDescriptorPropertiesResolver.java
@@ -91,9 +91,9 @@ public class MtaDescriptorPropertiesResolver {
             spaceIdSupplier, dao, cloudTarget);
         resolver.resolve(descriptor);
         LOGGER.debug(format(Messages.DEPLOYMENT_DESCRIPTOR_AFTER_CROSS_MTA_DEPENDENCY_RESOLUTION, secureSerializer.toJson(descriptor)));
-        LOGGER.debug(format(Messages.SUBSCRIPTIONS, secureSerializer.toJson(subscriptions)));
 
         subscriptions = createSubscriptions(descriptorWithUnresolvedReferences, resolver.getResolvedReferences());
+        LOGGER.debug(format(Messages.SUBSCRIPTIONS, secureSerializer.toJson(subscriptions)));
 
         descriptor = (DeploymentDescriptor) handlerFactory
             .getDescriptorReferenceResolver(descriptor, new ResolverBuilder(), new ResolverBuilder(), new ResolverBuilder())

--- a/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/cf/TaggingRequestInterceptorTest.java
+++ b/com.sap.cloud.lm.sl.cf.core/src/test/java/com/sap/cloud/lm/sl/cf/core/cf/TaggingRequestInterceptorTest.java
@@ -1,0 +1,142 @@
+package com.sap.cloud.lm.sl.cf.core.cf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.AbstractClientHttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
+
+import com.sap.cloud.lm.sl.cf.core.util.Configuration;
+
+import static org.mockito.Mockito.when;
+
+public class TaggingRequestInterceptorTest {
+
+    private static final String TEST_ORG_VALUE = "faceorg";
+    private static final String TEST_SPACE_VALUE = "myspace";
+    private org.springframework.http.HttpRequest requestStub;
+    private byte[] body = new byte[] {};
+    @Mock
+    private ClientHttpRequestExecution execution;
+
+    @Mock
+    private Configuration configuration;
+
+    @Before
+    public void setUp() {
+        requestStub = new AbstractClientHttpRequest() {
+            public URI getURI() {
+                return null;
+            }
+
+            public HttpMethod getMethod() {
+                return null;
+            }
+
+            protected OutputStream getBodyInternal(HttpHeaders headers) throws IOException {
+                return null;
+            }
+
+            protected ClientHttpResponse executeInternal(HttpHeaders headers) throws IOException {
+                return null;
+            }
+        };
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testInjectGenericValue() throws IOException {
+        TaggingRequestInterceptor testedInterceptor = new TaggingRequestInterceptor();
+        testedInterceptor.intercept(requestStub, body, execution);
+        assertNotNull(requestStub.getHeaders());
+        assertTrue(requestStub.getHeaders()
+            .containsKey(TaggingRequestInterceptor.TAG_HEADER_NAME));
+        String expectedValue = testedInterceptor.getHeaderValue();
+        Optional<String> foundValue = requestStub.getHeaders()
+            .get(TaggingRequestInterceptor.TAG_HEADER_NAME)
+            .stream()
+            .filter(value -> value.equals(expectedValue))
+            .findFirst();
+        assertTrue(foundValue.isPresent());
+    }
+
+    @Test
+    public void testInjectOrgAndSpaceValues() throws IOException {
+        TaggingRequestInterceptor testedInterceptor = new TaggingRequestInterceptor(TEST_ORG_VALUE, TEST_SPACE_VALUE);
+        testedInterceptor.intercept(requestStub, body, execution);
+        HttpHeaders headers = requestStub.getHeaders();
+        assertNotNull(headers);
+        assertTrue(headers.containsKey(TaggingRequestInterceptor.TAG_HEADER_ORG_NAME));
+        assertTrue(headers.containsKey(TaggingRequestInterceptor.TAG_HEADER_SPACE_NAME));
+        String expectedValue = testedInterceptor.getHeaderValue();
+        Optional<String> foundValue = headers.get(TaggingRequestInterceptor.TAG_HEADER_NAME)
+            .stream()
+            .filter(value -> value.equals(expectedValue))
+            .findFirst();
+        assertTrue(foundValue.isPresent());
+        Optional<String> foundOrgValue = headers.get(TaggingRequestInterceptor.TAG_HEADER_ORG_NAME)
+            .stream()
+            .filter(value -> value.equals(TEST_ORG_VALUE))
+            .findFirst();
+        assertTrue(foundOrgValue.isPresent());
+        Optional<String> foundSpaceValue = headers.get(TaggingRequestInterceptor.TAG_HEADER_SPACE_NAME)
+            .stream()
+            .filter(value -> value.equals(TEST_SPACE_VALUE))
+            .findFirst();
+        assertTrue(foundSpaceValue.isPresent());
+
+    }
+
+    @Test
+    public void testGetHeaderValue() throws IOException {
+        TaggingRequestInterceptor testedInterceptor = new TaggingRequestInterceptor(null, null) {
+            @Override
+            protected Configuration getConfiguration() {
+                return configuration;
+            }
+        };
+        final String dsversion = "9.9.9-SNAPSHOT";
+        when(configuration.getVersion()).thenReturn(dsversion);
+        String headerValue = testedInterceptor.getHeaderValue();
+        assertTrue(headerValue.contains(dsversion));
+        assertTrue(headerValue.contains("deploy-service"));
+    }
+
+    @Test
+    public void addHeadersOnlyOnceTest() throws IOException {
+        TaggingRequestInterceptor testedInterceptor = new TaggingRequestInterceptor(TEST_ORG_VALUE, TEST_SPACE_VALUE);
+        testedInterceptor.intercept(requestStub, body, execution);
+        testedInterceptor.intercept(requestStub, body, execution);
+        testedInterceptor.intercept(requestStub, body, execution);
+        HttpHeaders headers = requestStub.getHeaders();
+        String expectedValue = testedInterceptor.getHeaderValue();
+        long tagCount = headers.get(TaggingRequestInterceptor.TAG_HEADER_NAME)
+            .stream()
+            .filter(value -> value.equals(expectedValue))
+            .count();
+        assertEquals("Main tag header occurence is not 1", 1l, tagCount);
+        long orgTagCount = headers.get(TaggingRequestInterceptor.TAG_HEADER_ORG_NAME)
+            .stream()
+            .filter(value -> value.equals(TEST_ORG_VALUE))
+            .count();
+        assertEquals("Org tag header occurence is not 1", 1l, orgTagCount);
+        long spaceTagCount = headers.get(TaggingRequestInterceptor.TAG_HEADER_SPACE_NAME)
+            .stream()
+            .filter(value -> value.equals(TEST_SPACE_VALUE))
+            .count();
+        assertEquals("Space tag header occurence is not 1", 1l, spaceTagCount);
+    }
+}


### PR DESCRIPTION
In order for the calls comming from the deploy-service to be
distinguishable and easyer for analysis a custom request header is
appended to each request.

Done via a spring rest template rquest interceptor. Headers name :
source, source-org, source-space. The latter two are optional.

UNTRACKED