### PR TITLE
Fox bootstrap servlet fails to load if no async changes are present

### DIFF
--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/bootstrap/BootstrapServlet.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/bootstrap/BootstrapServlet.java
@@ -16,6 +16,7 @@ import javax.sql.DataSource;
 import org.activiti.engine.ProcessEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
@@ -61,7 +62,7 @@ public class BootstrapServlet extends HttpServlet {
     @Inject
     protected Configuration configuration;
 
-    @Inject
+    @Autowired(required = false)
     private List<AsyncChange> asyncChanges;
 
     @Inject


### PR DESCRIPTION
During the app bootstrap, async changes are started. Such
are injected by the spring framework and if no are currently applicable
(present in the context) the servlet should not fail to initialize.
This change replaces the Inject anotation with Autowired which allows
for the missing dependency to be ignored.

LMCROSSITXSADEPLOY-1021