### PR TITLE
Fix NPE in injectServiceKeysCredentialsInAppEnv

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateAppStepTest.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/java/com/sap/cloud/lm/sl/cf/process/steps/CreateAppStepTest.java
@@ -86,6 +86,8 @@ public class CreateAppStepTest extends SyncActivitiStepTest<CreateAppStep> {
                 "Unable to retrieve required service key element \"expected-service-key\" for service \"existing-service\"",
                 PlatformType.XS2
             },
+            // (7) Service keys to inject are null
+            { "create-app-step-input-08.json", null, PlatformType.XS2 },
 // @formatter:on
         });
     }

--- a/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/create-app-step-input-08.json
+++ b/com.sap.cloud.lm.sl.cf.process/src/test/resources/com/sap/cloud/lm/sl/cf/process/steps/create-app-step-input-08.json
@@ -1,0 +1,29 @@
+{
+  "applications": [
+    {
+      "name": "application-1",
+      "staging": {
+        "command": "command-1",
+        "buildpackUrl": "buildpackUrl-1",
+        "healthCheckType": "none"
+      },
+      "instances": 1,
+      "memory": 0,
+      "diskQuota": 512,
+      "uris": [
+        "http://localhost:9999",
+        "http://localhost:8888",
+        "http://localhost:7777"
+      ],
+      "env": [
+        "foo=foo",
+        "bar=bar",
+        "baz=baz"
+      ],
+      "services": [],
+      "serviceKeysToInject": null
+    }
+  ],
+  "applicationIndex": 0,
+  "existingServiceKeys" : {}
+}


### PR DESCRIPTION
This situation can happen when service broker part of the MTA is a subscriber for a
configuration and it should be restarted in app sub-process.
In app sub-process UpdateAppStep and CreateAppStep steps work with
CloudApplicationExtended which has property "serviceKeysToInject".
But when subscribed service broker are set in context they are stored as
CloudApplication objects which does not have property
"serviceKeysToInject".
The context is set in UpdateSubscribersStep with StepsUtil::setUpdatedServiceBrokerSubscribers

Jira: LMCROSSITXSADEPLOY-990